### PR TITLE
allow host_os to accept mingw64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -245,7 +245,7 @@ case "${host_os}" in
         LIBZMQ_CHECK_LANG_FLAG_PREPEND([-Ae])
         AC_CHECK_FUNCS(gethrtime)
         ;;
-    *mingw32*)
+    *mingw*)
         AC_DEFINE(ZMQ_HAVE_WINDOWS, 1, [Have Windows OS])
         AC_DEFINE(ZMQ_HAVE_MINGW32, 1, [Have MinGW32])
         AC_CHECK_HEADERS(windows.h)


### PR DESCRIPTION
Changes the pattern for the host_os matches to _mingw_ from _mingw32_ to accept both mingw32 and mingw64 versions.
