### PR TITLE
FD_SETSIZE Increase to 1024

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -266,7 +266,7 @@ case "${host_os}" in
             AC_MSG_ERROR([Building static libraries is not supported under MinGW32])
         fi
         
-	# Additional for windows to set FD_SETSIZE to a larger number
+	# Set FD_SETSIZE to 1024
 	CPPFLAGS=" -DFD_SETSIZE=1024 $CPPFLAGS"
         ;;
     *cygwin*)

--- a/configure.ac
+++ b/configure.ac
@@ -266,8 +266,8 @@ case "${host_os}" in
             AC_MSG_ERROR([Building static libraries is not supported under MinGW32])
         fi
         
-		# Additional for windows to set FD_SETSIZE to a larger number
-		CPPFLAGS=" -DFD_SETSIZE=1024 $CPPFLAGS"
+	# Additional for windows to set FD_SETSIZE to a larger number
+	CPPFLAGS=" -DFD_SETSIZE=1024 $CPPFLAGS"
         ;;
     *cygwin*)
         # Define on Cygwin to enable all library features

--- a/configure.ac
+++ b/configure.ac
@@ -265,6 +265,9 @@ case "${host_os}" in
         if test "x$enable_static" = "xyes"; then
             AC_MSG_ERROR([Building static libraries is not supported under MinGW32])
         fi
+        
+		# Additional for windows to set FD_SETSIZE to a larger number
+		CPPFLAGS=" -DFD_SETSIZE=1024 $CPPFLAGS"
         ;;
     *cygwin*)
         # Define on Cygwin to enable all library features


### PR DESCRIPTION
Sets FD_SETSIZE to 1024 under mingw systems, increasing it from the default of 64, and brings it into line with the previous limit for CMake builds on mingw.
